### PR TITLE
Fix pacman & frightened ghost collision detection

### DIFF
--- a/src/app/functions/pac-man/pacman.ts
+++ b/src/app/functions/pac-man/pacman.ts
@@ -148,6 +148,11 @@ const movePacman = (state: GameState, direction: number) => {
   const requestedIndex = state.pacmanCurrentIndex + direction
   if (checkForWall(state, requestedIndex)) return
 
+  /**
+   * check before and after pacman moves to see if he ate a frightened ghost
+   */
+  didPacmanEatGhost(state)
+
   const pacmanCurrentTile = state.squares[state.pacmanCurrentIndex]
   removePacman(pacmanCurrentTile, state)
 


### PR DESCRIPTION
This pull request fixes an issue with the collision detection between pacman and frightened ghosts. Previously, the collision detection was not properly checking if pacman ate a frightened ghost. This PR adds a check before and after pacman moves to see if he ate a frightened ghost.